### PR TITLE
Default config initialization shouldn't trigger debug warnings

### DIFF
--- a/lib/resque-unique_by_arity.rb
+++ b/lib/resque-unique_by_arity.rb
@@ -9,6 +9,7 @@ require 'resque-unique_in_queue'
 require 'resque-unique_at_runtime'
 
 require 'resque/unique_by_arity/configuration'
+require 'resque/unique_by_arity/configuration/validator'
 require 'resque/unique_by_arity/global_configuration'
 require 'resque/unique_by_arity'
 require 'resque/unique_by_arity/modulizer'

--- a/lib/resque/unique_by_arity/configuration.rb
+++ b/lib/resque/unique_by_arity/configuration.rb
@@ -52,14 +52,9 @@ module Resque
       end
 
       def validate
-        # The default config initialization shouldn't trigger any warnings.
-        if base_klass_name && logger
-          log "[#{base_klass_name}] :arity_for_uniqueness is set to #{arity_for_uniqueness}, but no uniqueness enforcement was turned on [:unique_at_runtime, :unique_in_queue, :unique_across_queues]" unless unique_at_runtime || unique_in_queue || unique_across_queues
-          log "[#{base_klass_name}] :lock_after_execution_period is set to #{lock_after_execution_period}, but :unique_at_runtime is not set" if lock_after_execution_period && !(unique_in_queue || unique_across_queues)
-          log "[#{base_klass_name}] :runtime_lock_timeout is set to #{runtime_lock_timeout}, but :unique_at_runtime is not set" if runtime_lock_timeout && !unique_at_runtime
-          log "[#{base_klass_name}] :runtime_requeue_interval is set to #{runtime_requeue_interval}, but :unique_at_runtime is not set" if runtime_requeue_interval && !unique_at_runtime
-          log "[#{base_klass_name}] :unique_in_queue and :unique_across_queues should not be set at the same time, as :unique_across_queues will always supercede :unique_in_queue" if unique_in_queue && unique_across_queues
-        end
+        return unless base_klass_name && logger
+
+        Validator.log_warnings(self)
       end
 
       def log(msg)

--- a/lib/resque/unique_by_arity/configuration/validator.rb
+++ b/lib/resque/unique_by_arity/configuration/validator.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'forwardable'
+
+module Resque
+  module UniqueByArity
+    class Configuration
+      class Validator
+        extend Forwardable
+
+        ARITY_FOR_UNIQUENESS_MSG = '[%<job_name>s] :arity_for_uniqueness is set to %<arity_for_uniqueness>d, but no uniqueness enforcement was turned on [:unique_at_runtime, :unique_in_queue, :unique_across_queues]'.freeze
+        LOCK_AFTER_EXEC_PERIOD_MSG = '[%<job_name>s] :lock_after_execution_period is set to %<lock_after_execution_period>d, but :unique_at_runtime is not set'.freeze
+        RUNTIME_LOCK_TIMEOUT_MSG = '[%<job_name>s] :runtime_lock_timeout is set to %<runtime_lock_timeout>s, but :unique_at_runtime is not set'.freeze
+        RUNTIME_REQUEUE_INTERVAL_MSG = '[%<job_name>s] :runtime_requeue_interval is set to %<runtime_requeue_interval>d, but :unique_at_runtime is not set'.freeze
+        CONCURRENT_CONFIG_MSG = '[%<job_name>] :unique_in_queue and :unique_across_queues should not be set at the same time, as :unique_across_queues will always supercede :unique_in_queue'.freeze
+
+        private_constant :ARITY_FOR_UNIQUENESS_MSG,
+                         :LOCK_AFTER_EXEC_PERIOD_MSG,
+                         :RUNTIME_LOCK_TIMEOUT_MSG,
+                         :RUNTIME_REQUEUE_INTERVAL_MSG,
+                         :CONCURRENT_CONFIG_MSG
+
+        def initialize(config)
+          @config = config
+        end
+
+        def log_warnings
+          validate_arity_for_uniqueness
+          validate_after_execution_period
+          validate_runtime_lock_timout
+          validate_runtime_requeue_interval
+        end
+
+        def self.log_warnings(*args)
+          new(*args).log_warnings
+        end
+
+        private
+
+        attr_reader :config
+        def_delegators :config,
+                       :arity_for_uniqueness,
+                       :base_klass_name,
+                       :lock_after_execution_period,
+                       :runtime_lock_timeout,
+                       :runtime_requeue_interval,
+                       :unique_across_queues,
+                       :unique_at_runtime,
+                       :unique_in_queue
+
+        def log(msg)
+          Resque::UniqueByArity.log(msg, config)
+        end
+
+        def default_config_value?(config_attr)
+          config.send(config_attr) == default_config(config_attr)
+        end
+
+        def default_config(attr)
+          Resque::UniqueByArity.configuration.send(attr)
+        end
+
+        def validate_runtime_requeue_interval
+          return if default_config_value?(:runtime_requeue_interval) ||
+                    unique_at_runtime
+
+          log format(
+            RUNTIME_REQUEUE_INTERVAL_MSG,
+            job_name: base_klass_name,
+            runtime_requeue_interval: runtime_requeue_interval
+          )
+        end
+
+        def validate_runtime_lock_timout
+          return if default_config_value?(:runtime_lock_timeout) ||
+                    unique_at_runtime
+
+          log format(
+            RUNTIME_LOCK_TIMEOUT_MSG,
+            job_name: base_klass_name,
+            runtime_lock_timeout: runtime_lock_timeout
+          )
+        end
+
+        def validate_after_execution_period
+          return if default_config_value?(:lock_after_execution_period) ||
+                    (unique_in_queue || unique_across_queues)
+
+          log format(
+            LOCK_AFTER_EXEC_PERIOD_MSG,
+            job_name: base_klass_name,
+            lock_after_execution_period: lock_after_execution_period
+          )
+        end
+
+        def validate_arity_for_uniqueness
+          return if arity_for_uniqueness == 1 ||
+                    (unique_at_runtime ||
+                     unique_in_queue ||
+                     unique_across_queues)
+
+          log format(
+            ARITY_FOR_UNIQUENESS_MSG,
+            job_name: base_klass_name,
+            arity_for_uniqueness: arity_for_uniqueness
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/resque/unique_by_arity/configuration/validator_spec.rb
+++ b/spec/resque/unique_by_arity/configuration/validator_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Resque::UniqueByArity::Configuration::Validator do
+  describe '#log_warnings' do
+    context 'when no configuration is set' do
+      let(:config) do
+        Resque::UniqueByArity::Configuration.new(
+          unique_in_queue: false,
+          unique_at_runtime: false,
+          unique_across_queues: false
+        )
+      end
+
+      subject { described_class.new(config) }
+
+      before do
+        allow(Resque::UniqueByArity).to receive(:log)
+
+        subject.log_warnings
+      end
+
+      it { expect(Resque::UniqueByArity).not_to have_received(:log) }
+    end
+
+    context 'when runtime_requeue_interval is set' do
+      let(:config) do
+        Resque::UniqueByArity::Configuration.new(
+          runtime_requeue_interval: 100
+        )
+      end
+
+      subject { described_class.new(config) }
+
+      before do
+        allow(Resque::UniqueByArity).to receive(:log)
+
+        subject.log_warnings
+      end
+
+      it { expect(Resque::UniqueByArity).to have_received(:log) }
+    end
+
+    context 'when runtime_lock_timeout is set' do
+      let(:config) do
+        Resque::UniqueByArity::Configuration.new(
+          runtime_lock_timeout: 100
+        )
+      end
+
+      subject { described_class.new(config) }
+
+      before do
+        allow(Resque::UniqueByArity).to receive(:log)
+
+        subject.log_warnings
+      end
+
+      it { expect(Resque::UniqueByArity).to have_received(:log) }
+    end
+
+    context 'when lock_after_execution_period is set' do
+      let(:config) do
+        Resque::UniqueByArity::Configuration.new(
+          lock_after_execution_period: 100
+        )
+      end
+
+      subject { described_class.new(config) }
+
+      before do
+        allow(Resque::UniqueByArity).to receive(:log)
+
+        subject.log_warnings
+      end
+
+      it { expect(Resque::UniqueByArity).to have_received(:log) }
+    end
+
+    context 'when arity_for_uniqueness is set' do
+      let(:config) do
+        Resque::UniqueByArity::Configuration.new(
+          arity_for_uniqueness: 100
+        )
+      end
+
+      subject { described_class.new(config) }
+
+      before do
+        allow(Resque::UniqueByArity).to receive(:log)
+
+        subject.log_warnings
+      end
+
+      it { expect(Resque::UniqueByArity).to have_received(:log) }
+    end
+  end
+end


### PR DESCRIPTION
#### What?

When debug mode is on, the gem logs wrong configuration warnings, but values that were defined as default shouldn't trigger warnings.

#### How?

This PR checks if the wrong value configuration came from a default definition before triggering warnings.