### PR TITLE
Adds configuration options for context-specific arity uniqueness rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Resque::UniqueByArity
 
-Because some jobs have parameters that you do not want to consider for 
+Because some jobs have parameters that you do not want to consider for
 determination of uniqueness.
 
 NOTE:
 
 I rewrote, and renamed, both `resque_solo` and `resque-lonely_job`, becuase they
- can't be used together.  Why?  Their `redis_key` methods directly conflict, 
+ can't be used together.  Why?  Their `redis_key` methods directly conflict,
  among other more subtle issues.
 
 This gem requires use of my rewritten gems for uniqueness enforcement:
@@ -105,7 +105,7 @@ Create an initializer (e.g. `config/initializers/resque-unique_by_arity.rb` for 
 ### Per Job Class Configuration
 
 This gem will take care to set the class instance variables (similar to the
- familiar `@queue` class instance variable) that are utilized by 
+ familiar `@queue` class instance variable) that are utilized by
  `resque-unique_in_queue` and `resque-unique_at_runtime` (default values shown):
 
  ```ruby
@@ -168,7 +168,7 @@ class MyJob
     # Because the third argument is optional the arity valdiation will not approve.
     # Arguments to be considered for uniqueness should be required arguments.
     # The warning log might look like:
-    # 
+    #
     #    MyJob.perform has the following required parameters: [:my, :cat], which is not enough to satisfy the configured arity_for_uniqueness of 3
   end
   include Resque::Plugins::UniqueByArity.new(
@@ -233,7 +233,7 @@ end
 ```
 
 #### Oops, I have stale runtime uniqueness keys for MyJob stored in Redis...
- 
+
 Preventing jobs with matching signatures from running, and they never get
 dequeued because there is no actual corresponding job to dequeue.
 
@@ -278,7 +278,7 @@ end
 ```
 
 #### Oops, I have stale Queue Time uniqueness keys...
- 
+
 Preventing jobs with matching signatures from being queued, and they never get
 dequeued because there is no actual corresponding job to dequeue.
 
@@ -358,9 +358,9 @@ class MyJob
     #...
   )
 
-  # Core hashing algorithm for a job used for *all 3 types* of uniqueness 
-  # @return [Array<String, arguments>], where the string is the unique digest, and arguments are the specific args that were used to calculate the digest 
-  def self.redis_unique_hash(payload)
+  # Core hashing algorithm for a job used for *all 3 types* of uniqueness
+  # @return [Array<String, arguments>], where the string is the unique digest, and arguments are the specific args that were used to calculate the digest
+  def self.redis_unique_hash(payload, arity_for_uniqueness = 1)
     #       for how the built-in version works
     # uniqueness_args = payload["args"] # over simplified & ignoring arity
     # args = { class: job, args: uniqueness_args }
@@ -370,9 +370,10 @@ class MyJob
   def self.unique_in_queue_redis_key_prefix
     # "unique_job:#{self}" # <= default value
   end
-  
+
   def self.unique_in_queue_redis_key(queue, payload)
-    # unique_hash, _args_for_uniqueness = redis_unique_hash(payload)
+    # arity_for_uniqueness = determine_arity # over simplified & ignoring context-specific arity determination
+    # unique_hash, _args_for_uniqueness = redis_unique_hash(payload, arity_for_uniqueness)
     # "#{unique_in_queue_key_namespace(queue)}:#{unique_in_queue_redis_key_prefix}:#{unique_hash}"
   end
 
@@ -381,13 +382,14 @@ class MyJob
     # "r-uiq:queue:#{queue}:job" # <= is for unique within queue at queue time
     # "r-uiq:across_queues:job" # <= is for unique across all queues at queue time
   end
-  
+
   def self.runtime_key_namespace
     # "unique_at_runtime:#{self}"
   end
-  
+
   def self.unique_at_runtime_redis_key(*args)
-    # unique_hash, _args_for_uniqueness = redis_unique_hash({"class" => self.to_s, "args" => args})
+    # payload = {"class" => self.to_s, "args" => args}
+    # unique_hash, _args_for_uniqueness = redis_unique_hash(payload, configuration.arity_for_uniqueness_at_runtime)
     # key = "#{runtime_key_namespace}:#{unique_hash}" # <= simplified default
   end
 end
@@ -436,7 +438,7 @@ spec.add_dependency 'resque-unique_by_arity', '~> 0.0'
 
 * Copyright (c) 2017 - 2018 [Peter H. Boling][peterboling] of [Rails Bling][railsbling]
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT) 
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
 [license]: LICENSE
 [semver]: http://semver.org/

--- a/lib/resque/unique_by_arity/configuration.rb
+++ b/lib/resque/unique_by_arity/configuration.rb
@@ -11,6 +11,9 @@ module Resque
       attr_accessor :logger
       attr_accessor :log_level
       attr_accessor :arity_for_uniqueness
+      attr_accessor :arity_for_uniqueness_at_runtime
+      attr_accessor :arity_for_uniqueness_in_queue
+      attr_accessor :arity_for_uniqueness_across_queues
       attr_accessor :arity_validation
       attr_accessor :lock_after_execution_period
       attr_accessor :runtime_lock_timeout
@@ -28,6 +31,9 @@ module Resque
         @logger = options.key?(:logger) ? options[:logger] : defcon(:logger) || Logger.new(STDOUT)
         @log_level = options.key?(:log_level) ? options[:log_level] : defcon(:log_level) || :debug
         @arity_for_uniqueness = options.key?(:arity_for_uniqueness) ? options[:arity_for_uniqueness] : defcon(:arity_for_uniqueness) || 1
+        @arity_for_uniqueness_at_runtime = options.key?(:arity_for_uniqueness_at_runtime) ? options[:arity_for_uniqueness_at_runtime] : defcon(:arity_for_uniqueness_at_runtime) || @arity_for_uniqueness
+        @arity_for_uniqueness_in_queue = options.key?(:arity_for_uniqueness_in_queue) ? options[:arity_for_uniqueness_in_queue] : defcon(:arity_for_uniqueness_in_queue) || @arity_for_uniqueness
+        @arity_for_uniqueness_across_queues = options.key?(:arity_for_uniqueness_across_queues) ? options[:arity_for_uniqueness_across_queues] : defcon(:arity_for_uniqueness_across_queues) || @arity_for_uniqueness
         @arity_validation = options.key?(:arity_validation) ? options[:arity_validation] : defcon(:arity_validation) || :warning
         raise ArgumentError, "Resque::Plugins::UniqueByArity.new requires arity_validation values of #{arity_validation.inspect}, or a class inheriting from Exception, but the value is #{@arity_validation} (#{@arity_validation.class})" unless VALID_ARITY_VALIDATION_LEVELS.include?(@arity_validation) || !@arity_validation.respond_to?(:ancestors) || @arity_validation.ancestors.include?(Exception)
 
@@ -66,6 +72,9 @@ module Resque
           log_level: log_level,
           logger: logger,
           arity_for_uniqueness: arity_for_uniqueness,
+          arity_for_uniqueness_at_runtime: arity_for_uniqueness_at_runtime,
+          arity_for_uniqueness_in_queue: arity_for_uniqueness_in_queue,
+          arity_for_uniqueness_across_queues: arity_for_uniqueness_across_queues,
           arity_validation: arity_validation,
           base_klass_name: base_klass_name,
           debug_mode: debug_mode,

--- a/lib/resque/unique_by_arity/configuration/validator.rb
+++ b/lib/resque/unique_by_arity/configuration/validator.rb
@@ -9,12 +9,18 @@ module Resque
         extend Forwardable
 
         ARITY_FOR_UNIQUENESS_MSG = '[%<job_name>s] :arity_for_uniqueness is set to %<arity_for_uniqueness>d, but no uniqueness enforcement was turned on [:unique_at_runtime, :unique_in_queue, :unique_across_queues]'.freeze
+        ARITY_FOR_UNIQUENESS_AT_RUNTIME_MSG = '[%<job_name>s] :arity_for_uniqueness_at_runtime is set to %<arity_for_uniqueness_at_runtime>d, but :unique_at_runtime was not turned on'.freeze
+        ARITY_FOR_UNIQUENESS_IN_QUEUE_MSG = '[%<job_name>s] :arity_for_uniqueness_in_queue is set to %<arity_for_uniqueness_in_queue>d, but :unique_in_queue was not turned on'.freeze
+        ARITY_FOR_UNIQUENESS_ACROSS_QUEUES_MSG = '[%<job_name>s] :arity_for_uniqueness_across_queues is set to %<arity_for_uniqueness_across_queues>d, but :unique_across_queues was not turned on'.freeze
         LOCK_AFTER_EXEC_PERIOD_MSG = '[%<job_name>s] :lock_after_execution_period is set to %<lock_after_execution_period>d, but :unique_at_runtime is not set'.freeze
         RUNTIME_LOCK_TIMEOUT_MSG = '[%<job_name>s] :runtime_lock_timeout is set to %<runtime_lock_timeout>s, but :unique_at_runtime is not set'.freeze
         RUNTIME_REQUEUE_INTERVAL_MSG = '[%<job_name>s] :runtime_requeue_interval is set to %<runtime_requeue_interval>d, but :unique_at_runtime is not set'.freeze
         CONCURRENT_CONFIG_MSG = '[%<job_name>] :unique_in_queue and :unique_across_queues should not be set at the same time, as :unique_across_queues will always supercede :unique_in_queue'.freeze
 
         private_constant :ARITY_FOR_UNIQUENESS_MSG,
+                         :ARITY_FOR_UNIQUENESS_AT_RUNTIME_MSG,
+                         :ARITY_FOR_UNIQUENESS_IN_QUEUE_MSG,
+                         :ARITY_FOR_UNIQUENESS_ACROSS_QUEUES_MSG,
                          :LOCK_AFTER_EXEC_PERIOD_MSG,
                          :RUNTIME_LOCK_TIMEOUT_MSG,
                          :RUNTIME_REQUEUE_INTERVAL_MSG,
@@ -26,6 +32,9 @@ module Resque
 
         def log_warnings
           validate_arity_for_uniqueness
+          validate_arity_for_uniqueness_at_runtime
+          validate_arity_for_uniqueness_in_queue
+          validate_arity_for_uniqueness_across_queues
           validate_after_execution_period
           validate_runtime_lock_timout
           validate_runtime_requeue_interval
@@ -40,6 +49,9 @@ module Resque
         attr_reader :config
         def_delegators :config,
                        :arity_for_uniqueness,
+                       :arity_for_uniqueness_at_runtime,
+                       :arity_for_uniqueness_in_queue,
+                       :arity_for_uniqueness_across_queues,
                        :base_klass_name,
                        :lock_after_execution_period,
                        :runtime_lock_timeout,
@@ -103,6 +115,36 @@ module Resque
             ARITY_FOR_UNIQUENESS_MSG,
             job_name: base_klass_name,
             arity_for_uniqueness: arity_for_uniqueness
+          )
+        end
+
+        def validate_arity_for_uniqueness_at_runtime
+          return if arity_for_uniqueness_at_runtime == arity_for_uniqueness || unique_at_runtime
+
+          log format(
+            ARITY_FOR_UNIQUENESS_AT_RUNTIME_MSG,
+            job_name: base_klass_name,
+            arity_for_uniqueness_at_runtime: arity_for_uniqueness_at_runtime
+          )
+        end
+
+        def validate_arity_for_uniqueness_in_queue
+          return if arity_for_uniqueness_in_queue == arity_for_uniqueness || unique_in_queue
+
+          log format(
+            ARITY_FOR_UNIQUENESS_IN_QUEUE_MSG,
+            job_name: base_klass_name,
+            arity_for_uniqueness_in_queue: arity_for_uniqueness_in_queue
+          )
+        end
+
+        def validate_arity_for_uniqueness_across_queues
+          return if arity_for_uniqueness_across_queues == arity_for_uniqueness || unique_across_queues
+
+          log format(
+            ARITY_FOR_UNIQUENESS_ACROSS_QUEUES_MSG,
+            job_name: base_klass_name,
+            arity_for_uniqueness_across_queues: arity_for_uniqueness_across_queues
           )
         end
       end

--- a/lib/resque/unique_by_arity/global_configuration.rb
+++ b/lib/resque/unique_by_arity/global_configuration.rb
@@ -32,6 +32,9 @@ module Resque
         @logger = nil
         @log_level = DEFAULT_LOG_LEVEL
         @arity_for_uniqueness = nil
+        @arity_for_uniqueness_at_runtime = nil
+        @arity_for_uniqueness_in_queue = nil
+        @arity_for_uniqueness_across_queues = nil
         @arity_validation = nil
         @lock_after_execution_period = DEFAULT_LOCK_AFTER_EXECUTION_PERIOD
         @runtime_lock_timeout = DEFAULT_LOCK_TIMEOUT

--- a/resque-unique_by_arity.gemspec
+++ b/resque-unique_by_arity.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'resque-unique_in_queue', '>= 2'
   spec.add_runtime_dependency 'resque-unique_at_runtime', '>= 3'
 
-  spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'bundler', '~> 2.0.2'
   spec.add_development_dependency 'byebug', '~> 10.0'
   spec.add_development_dependency 'pry', '~> 0.11'
   spec.add_development_dependency 'pry-byebug', '~> 3.6'

--- a/spec/resque/unique_by_arity/configuration/validator_spec.rb
+++ b/spec/resque/unique_by_arity/configuration/validator_spec.rb
@@ -95,5 +95,59 @@ describe Resque::UniqueByArity::Configuration::Validator do
 
       it { expect(Resque::UniqueByArity).to have_received(:log) }
     end
+
+    context 'when arity_for_uniqueness_at_runtime is set' do
+      let(:config) do
+        Resque::UniqueByArity::Configuration.new(
+          arity_for_uniqueness_at_runtime: 100
+        )
+      end
+
+      subject { described_class.new(config) }
+
+      before do
+        allow(Resque::UniqueByArity).to receive(:log)
+
+        subject.log_warnings
+      end
+
+      it { expect(Resque::UniqueByArity).to have_received(:log) }
+    end
+
+    context 'when arity_for_uniqueness_in_queue is set' do
+      let(:config) do
+        Resque::UniqueByArity::Configuration.new(
+          arity_for_uniqueness_in_queue: 100
+        )
+      end
+
+      subject { described_class.new(config) }
+
+      before do
+        allow(Resque::UniqueByArity).to receive(:log)
+
+        subject.log_warnings
+      end
+
+      it { expect(Resque::UniqueByArity).to have_received(:log) }
+    end
+
+    context 'when arity_for_uniqueness_across_queues is set' do
+      let(:config) do
+        Resque::UniqueByArity::Configuration.new(
+          arity_for_uniqueness_across_queues: 100
+        )
+      end
+
+      subject { described_class.new(config) }
+
+      before do
+        allow(Resque::UniqueByArity).to receive(:log)
+
+        subject.log_warnings
+      end
+
+      it { expect(Resque::UniqueByArity).to have_received(:log) }
+    end
   end
 end

--- a/spec/resque/unique_by_arity/configuration_spec.rb
+++ b/spec/resque/unique_by_arity/configuration_spec.rb
@@ -7,6 +7,9 @@ describe Resque::UniqueByArity::Configuration do
     let(:log_level) { :info }
     let(:logger) { Logger.new('/dev/null') }
     let(:arity_for_uniqueness) { 0 }
+    let(:arity_for_uniqueness_at_runtime) { 0 }
+    let(:arity_for_uniqueness_in_queue) { 0 }
+    let(:arity_for_uniqueness_across_queues) { 0 }
     let(:arity_validation) { :warning }
     let(:lock_after_execution_period) { nil }
     let(:runtime_lock_timeout) { 10 }
@@ -25,6 +28,9 @@ describe Resque::UniqueByArity::Configuration do
           logger: logger,
           log_level: log_level,
           arity_for_uniqueness: arity_for_uniqueness,
+          arity_for_uniqueness_at_runtime: arity_for_uniqueness_at_runtime,
+          arity_for_uniqueness_in_queue: arity_for_uniqueness_in_queue,
+          arity_for_uniqueness_across_queues: arity_for_uniqueness_across_queues,
           arity_validation: arity_validation,
           lock_after_execution_period: lock_after_execution_period,
           runtime_lock_timeout: runtime_lock_timeout,
@@ -61,6 +67,24 @@ describe Resque::UniqueByArity::Configuration do
         subject { instance.arity_for_uniqueness }
         it 'sets arity_for_uniqueness' do
           is_expected.to eq(arity_for_uniqueness)
+        end
+      end
+      context 'arity_for_uniqueness_at_runtime option' do
+        subject { instance.arity_for_uniqueness_at_runtime }
+        it 'sets arity_for_uniqueness_at_runtime' do
+          is_expected.to eq(arity_for_uniqueness_at_runtime)
+        end
+      end
+      context 'arity_for_uniqueness_in_queue option' do
+        subject { instance.arity_for_uniqueness_in_queue }
+        it 'sets arity_for_uniqueness_in_queue' do
+          is_expected.to eq(arity_for_uniqueness_in_queue)
+        end
+      end
+      context 'arity_for_uniqueness_across_queues option' do
+        subject { instance.arity_for_uniqueness_across_queues }
+        it 'sets arity_for_uniqueness_across_queues' do
+          is_expected.to eq(arity_for_uniqueness_across_queues)
         end
       end
       context 'arity_validation option' do
@@ -155,6 +179,9 @@ describe Resque::UniqueByArity::Configuration do
                               log_level: :info,
                               logger: logger,
                               arity_for_uniqueness: arity_for_uniqueness,
+                              arity_for_uniqueness_at_runtime: arity_for_uniqueness_at_runtime,
+                              arity_for_uniqueness_in_queue: arity_for_uniqueness_in_queue,
+                              arity_for_uniqueness_across_queues: arity_for_uniqueness_across_queues,
                               arity_validation: arity_validation,
                               base_klass_name: nil, # Not set by initialize!
                               debug_mode: false, # normalized to true || false

--- a/spec/resque/unique_by_arity_spec.rb
+++ b/spec/resque/unique_by_arity_spec.rb
@@ -18,6 +18,15 @@ RSpec.describe Resque::UniqueByArity do
     it 'has default arity_for_uniqueness' do
       expect(Resque::UniqueByArity.configuration.arity_for_uniqueness).to eq(nil)
     end
+    it 'has default arity_for_uniqueness_at_runtime' do
+      expect(Resque::UniqueByArity.configuration.arity_for_uniqueness_at_runtime).to eq(nil)
+    end
+    it 'has default arity_for_uniqueness_in_queue' do
+      expect(Resque::UniqueByArity.configuration.arity_for_uniqueness_in_queue).to eq(nil)
+    end
+    it 'has default arity_for_uniqueness_across_queues' do
+      expect(Resque::UniqueByArity.configuration.arity_for_uniqueness_across_queues).to eq(nil)
+    end
     it 'has default arity_validation' do
       expect(Resque::UniqueByArity.configuration.arity_validation).to eq(nil)
     end
@@ -56,6 +65,9 @@ RSpec.describe Resque::UniqueByArity do
       let(:logger) { Logger.new('/dev/null') }
       let(:log_level) { :info }
       let(:arity_for_uniqueness) { 3 }
+      let(:arity_for_uniqueness_at_runtime) { 1 }
+      let(:arity_for_uniqueness_in_queue) { 3 }
+      let(:arity_for_uniqueness_across_queues) { 3 }
       let(:unique_at_runtime) { true }
       let(:unique_in_queue) { true }
       let(:runtime_lock_timeout) { 10 }
@@ -70,6 +82,9 @@ RSpec.describe Resque::UniqueByArity do
           config.logger = logger
           config.log_level = log_level
           config.arity_for_uniqueness = arity_for_uniqueness
+          config.arity_for_uniqueness_at_runtime = arity_for_uniqueness_at_runtime
+          config.arity_for_uniqueness_in_queue = arity_for_uniqueness_in_queue
+          config.arity_for_uniqueness_across_queues = arity_for_uniqueness_across_queues
           config.unique_at_runtime = unique_at_runtime
           config.unique_in_queue = unique_in_queue
           config.runtime_lock_timeout = runtime_lock_timeout
@@ -90,6 +105,9 @@ RSpec.describe Resque::UniqueByArity do
         expect(Resque::UniqueByArity.configuration.logger).to eq(logger)
         expect(Resque::UniqueByArity.configuration.log_level).to eq(log_level)
         expect(Resque::UniqueByArity.configuration.arity_for_uniqueness).to eq(arity_for_uniqueness)
+        expect(Resque::UniqueByArity.configuration.arity_for_uniqueness_at_runtime).to eq(arity_for_uniqueness_at_runtime)
+        expect(Resque::UniqueByArity.configuration.arity_for_uniqueness_in_queue).to eq(arity_for_uniqueness_in_queue)
+        expect(Resque::UniqueByArity.configuration.arity_for_uniqueness_across_queues).to eq(arity_for_uniqueness_across_queues)
         expect(Resque::UniqueByArity.configuration.unique_at_runtime).to eq(unique_at_runtime)
         expect(Resque::UniqueByArity.configuration.unique_in_queue).to eq(unique_in_queue)
         expect(Resque::UniqueByArity.configuration.runtime_lock_timeout).to eq(runtime_lock_timeout)


### PR DESCRIPTION
**Problem**
We needed the ability to set arity uniqueness rules based on the type of uniqueness desired (`unique_at_runtime`, `unique_in_queue`, `unique_across_queues`). Some of our jobs need to be unique at runtime for the first parameter, but re-queable with different second and third parameters.

**Solution**
This PR adds 3 new configuration options (`arity_for_uniqueness_at_runtime`, `arity_for_uniqueness_in_queue`, `arity_for_uniqueness_across_queues`) which allow us to handle the complex uniqueness rules of our application.